### PR TITLE
Add optional button support for ADS1115 joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Pi5-ps2-joystick-tools
-树莓派 Pi5的ps2 摇杆模块的使用
+
+这是一个示例仓库，展示如何在树莓派 Pi5 上通过 ADS1115 模数转换器读取 PS2 摇杆模块的数值。
+
+## 连接方式
+
+1. 将摇杆的 `VRx` 尖脚连接到 ADS1115 的 `A0`（`P0`）。
+2. 将摇杆的 `VRy` 尖脚连接到 ADS1115 的 `A1`（`P1`）。
+3. *(可选)* 将摇杆的按键尖脚连接到树莓派的某个 GPIO（示例中为 GPIO17）。如果只需要 X/Y 两个模拟量，可不接此线，并在代码中禁用按键读取。
+4. 其余电源和 GND 尖脚按常规方式接线。
+
+如果没有连接按键线，在创建 `Joystick` 实例时将 `button_pin` 参数设为 `None`：
+
+```python
+from joystick import Joystick
+
+joy = Joystick(button_pin=None)
+```
+
+## 运行示例
+
+仓库中提供了两个 Python 脚本，分别依赖 `gpiozero` 和 `adafruit-circuitpython-ads1x15`。安装依赖后你可以以以下方式运行：
+
+```bash
+pip install gpiozero adafruit-blinka adafruit-circuitpython-ads1x15
+python examples/main.py
+```
+
+`examples/main.py` 使用 `examples/joystick.py`中的 `Joystick` 类来读取摇杆数据，并周期输出 X/、Y 值及按键状态。按 `Ctrl+C` 可退出。

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -1,0 +1,25 @@
+"""Utility module to read a PS2 joystick using an ADS1115 ADC."""
+
+from adafruit_ads1x15 import ads1115 as ADS
+from adafruit_ads1x15.analog_in import AnalogIn
+from typing import Optional
+
+from gpiozero import Button
+import board
+import busio
+
+
+class Joystick:
+    """Represents a PS2 joystick connected via ADS1115."""
+
+    def __init__(self, x_channel=ADS.P0, y_channel=ADS.P1, button_pin: Optional[int] = 17):
+        i2c = busio.I2C(board.SCL, board.SDA)
+        self.ads = ADS.ADS1115(i2c)
+        self.x_axis = AnalogIn(self.ads, x_channel)
+        self.y_axis = AnalogIn(self.ads, y_channel)
+        self.switch = Button(button_pin) if button_pin is not None else None
+
+    def read(self):
+        """Return a tuple of (x_value, y_value, pressed)."""
+        pressed = self.switch.is_pressed if self.switch else False
+        return self.x_axis.value, self.y_axis.value, pressed

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,0 +1,16 @@
+"""Example script for reading the PS2 joystick using ADS1115."""
+
+from time import sleep
+from joystick import Joystick
+
+
+joy = Joystick()
+
+print("Press Ctrl+C to exit")
+try:
+    while True:
+        x, y, pressed = joy.read()
+        print(f"X: {x} | Y: {y} | Button: {pressed}")
+        sleep(0.2)
+except KeyboardInterrupt:
+    print("\nExiting...")


### PR DESCRIPTION
## Summary
- allow disabling the button input in `Joystick`
- document how to omit the button wiring in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884d31025648331b76eb1d603c65f4d