### PR TITLE
Handle GPIO busy error gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ python examples/main.py
 ```
 
 `examples/main.py` 使用 `examples/joystick.py`中的 `Joystick` 类来读取摇杆数据，并周期输出 X/、Y 值及按键状态。按 `Ctrl+C` 可退出。
+
+如果在初始化按键时出现 `GPIO busy` 错误，说明该 GPIO 可能已被其它进程占用。
+此时可在创建 `Joystick` 时传入 `button_pin=None` 以禁用按键读取，或检查系统中
+占用该引脚的程序。

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -5,6 +5,7 @@ from adafruit_ads1x15.analog_in import AnalogIn
 from typing import Optional
 
 from gpiozero import Button
+import warnings
 import board
 import busio
 
@@ -17,7 +18,12 @@ class Joystick:
         self.ads = ADS.ADS1115(i2c)
         self.x_axis = AnalogIn(self.ads, x_channel)
         self.y_axis = AnalogIn(self.ads, y_channel)
-        self.switch = Button(button_pin) if button_pin is not None else None
+        self.switch = None
+        if button_pin is not None:
+            try:
+                self.switch = Button(button_pin)
+            except Exception as e:
+                warnings.warn(f"Failed to initialize button on GPIO {button_pin}: {e}")
 
     def read(self):
         """Return a tuple of (x_value, y_value, pressed)."""


### PR DESCRIPTION
## Summary
- avoid crash when joystick button pin is busy
- document workaround for `GPIO busy` errors

## Testing
- `python -m py_compile examples/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6885aabdcbf08331872757eb148a9a79