### PR TITLE
Remove unused button functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,16 @@
 
 1. 将摇杆的 `VRx` 尖脚连接到 ADS1115 的 `A0`（`P0`）。
 2. 将摇杆的 `VRy` 尖脚连接到 ADS1115 的 `A1`（`P1`）。
-3. *(可选)* 将摇杆的按键尖脚连接到树莓派的某个 GPIO（示例中为 GPIO17）。如果只需要 X/Y 两个模拟量，可不接此线，并在代码中禁用按键读取。
-4. 其余电源和 GND 尖脚按常规方式接线。
+3. 其余电源和 GND 尖脚按常规方式接线。
 
-如果没有连接按键线，在创建 `Joystick` 实例时将 `button_pin` 参数设为 `None`：
-
-```python
-from joystick import Joystick
-
-joy = Joystick(button_pin=None)
-```
 
 ## 运行示例
 
-仓库中提供了两个 Python 脚本，分别依赖 `gpiozero` 和 `adafruit-circuitpython-ads1x15`。安装依赖后你可以以以下方式运行：
+仓库中提供了两个 Python 脚本，依赖 `adafruit-circuitpython-ads1x15`。安装依赖后可以通过以下命令运行：
 
 ```bash
-pip install gpiozero adafruit-blinka adafruit-circuitpython-ads1x15 lgpio
+pip install adafruit-blinka adafruit-circuitpython-ads1x15
 python examples/main.py
 ```
 
-`examples/main.py` 使用 `examples/joystick.py`中的 `Joystick` 类来读取摇杆数据，并周期输出 X/、Y 值及按键状态。按 `Ctrl+C` 可退出。
-
-如果在初始化按键时出现 `GPIO busy` 错误，说明该 GPIO 可能已被其它进程占用。
-此时可在创建 `Joystick` 时传入 `button_pin=None` 以禁用按键读取，或检查系统中
-占用该引脚的程序。
+`examples/main.py` 使用 `examples/joystick.py`中的 `Joystick` 类来读取摇杆数据，并周期输出 X、Y 值。按 `Ctrl+C` 可退出。

--- a/examples/joystick.py
+++ b/examples/joystick.py
@@ -2,10 +2,6 @@
 
 from adafruit_ads1x15 import ads1115 as ADS
 from adafruit_ads1x15.analog_in import AnalogIn
-from typing import Optional
-
-from gpiozero import Button
-import warnings
 import board
 import busio
 
@@ -13,19 +9,12 @@ import busio
 class Joystick:
     """Represents a PS2 joystick connected via ADS1115."""
 
-    def __init__(self, x_channel=ADS.P0, y_channel=ADS.P1, button_pin: Optional[int] = 17):
+    def __init__(self, x_channel=ADS.P0, y_channel=ADS.P1):
         i2c = busio.I2C(board.SCL, board.SDA)
         self.ads = ADS.ADS1115(i2c)
         self.x_axis = AnalogIn(self.ads, x_channel)
         self.y_axis = AnalogIn(self.ads, y_channel)
-        self.switch = None
-        if button_pin is not None:
-            try:
-                self.switch = Button(button_pin)
-            except Exception as e:
-                warnings.warn(f"Failed to initialize button on GPIO {button_pin}: {e}")
 
     def read(self):
-        """Return a tuple of (x_value, y_value, pressed)."""
-        pressed = self.switch.is_pressed if self.switch else False
-        return self.x_axis.value, self.y_axis.value, pressed
+        """Return a tuple of (x_value, y_value)."""
+        return self.x_axis.value, self.y_axis.value

--- a/examples/main.py
+++ b/examples/main.py
@@ -9,8 +9,8 @@ joy = Joystick()
 print("Press Ctrl+C to exit")
 try:
     while True:
-        x, y, pressed = joy.read()
-        print(f"X: {x} | Y: {y} | Button: {pressed}")
+        x, y = joy.read()
+        print(f"X: {x} | Y: {y}")
         sleep(0.2)
 except KeyboardInterrupt:
     print("\nExiting...")


### PR DESCRIPTION
## Summary
- remove button initialization from `Joystick`
- update example script accordingly
- simplify README instructions

## Testing
- `python -m py_compile examples/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6885abdc100883318821e9543bc7b320